### PR TITLE
Add Redis quota circuit breaker

### DIFF
--- a/DistributedCircuitBreaker.Redis.sln
+++ b/DistributedCircuitBreaker.Redis.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -13,6 +13,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedCircuitBreaker.Benchmarks", "benchmarks\DistributedCircuitBreaker.Benchmarks\DistributedCircuitBreaker.Benchmarks.csproj", "{6DFED68B-16CA-48EA-99BA-AB943460C075}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Web", "samples\Sample.Web\Sample.Web.csproj", "{54751268-B034-4AFA-B793-FB79C79C5157}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7CD764B9-3170-420A-9A4D-D01BCE6C7153}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DistributedQuotaCircuitBreaker.Redis", "src\DistributedQuotaCircuitBreaker.Redis\DistributedQuotaCircuitBreaker.Redis.csproj", "{2EC1A16C-6F1F-4545-AC40-9756FADF4B16}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,8 +48,15 @@ Global
 		{54751268-B034-4AFA-B793-FB79C79C5157}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54751268-B034-4AFA-B793-FB79C79C5157}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54751268-B034-4AFA-B793-FB79C79C5157}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EC1A16C-6F1F-4545-AC40-9756FADF4B16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EC1A16C-6F1F-4545-AC40-9756FADF4B16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EC1A16C-6F1F-4545-AC40-9756FADF4B16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EC1A16C-6F1F-4545-AC40-9756FADF4B16}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2EC1A16C-6F1F-4545-AC40-9756FADF4B16} = {7CD764B9-3170-420A-9A4D-D01BCE6C7153}
 	EndGlobalSection
 EndGlobal

--- a/src/DistributedQuotaCircuitBreaker.Redis/DistributedQuotaCircuitBreaker.Redis.csproj
+++ b/src/DistributedQuotaCircuitBreaker.Redis/DistributedQuotaCircuitBreaker.Redis.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Redis-backed quota-based circuit breaker that routes to a secondary endpoint when the primary quota is exceeded.</Description>
+    <PackageId>DistributedQuotaCircuitBreaker.Redis</PackageId>
+    <PackageReleaseNotes>
+      Provides a Redis-based quota circuit breaker that counts requests against a quota window and switches to a secondary endpoint when the quota is exceeded.
+    </PackageReleaseNotes>
+    <PackageTags>$(PackageTags);quota;redis;circuit-breaker</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="2.9.11" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="MinVer" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/DistributedQuotaCircuitBreaker.Redis/RedisQuotaCircuitBreaker.cs
+++ b/src/DistributedQuotaCircuitBreaker.Redis/RedisQuotaCircuitBreaker.cs
@@ -1,0 +1,69 @@
+using StackExchange.Redis;
+
+namespace DistributedQuotaCircuitBreaker.Redis;
+
+/// <summary>
+/// Redis-backed quota circuit breaker for selecting between primary and secondary endpoints.
+/// </summary>
+/// <remarks>
+/// The circuit breaker increments a Redis counter for each request routed to the primary endpoint.
+/// When the configured quota is exceeded within the quota period, subsequent requests are routed to
+/// the secondary endpoint until the Redis key expires. The key's time-to-live acts as the quota reset
+/// interval, ensuring that traffic returns to the primary endpoint once the period elapses.
+/// </remarks>
+public sealed class RedisQuotaCircuitBreaker
+{
+    private readonly IDatabase _db;
+    private readonly string _countKey;
+    private readonly int _quota;
+    private readonly TimeSpan _period;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RedisQuotaCircuitBreaker"/> class.
+    /// </summary>
+    /// <param name="mux">Redis connection multiplexer.</param>
+    /// <param name="key">Unique key used to track quota usage in Redis.</param>
+    /// <param name="quota">Number of requests allowed within the period for the primary endpoint.</param>
+    /// <param name="period">Quota reset interval.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="mux"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="key"/> is null or whitespace.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quota"/> is not positive or <paramref name="period"/> is non-positive.</exception>
+    public RedisQuotaCircuitBreaker(IConnectionMultiplexer mux, string key, int quota, TimeSpan period)
+    {
+        if (mux == null) throw new ArgumentNullException(nameof(mux));
+        if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key cannot be null or empty", nameof(key));
+        if (quota <= 0) throw new ArgumentOutOfRangeException(nameof(quota));
+        if (period <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period));
+
+        _db = mux.GetDatabase();
+        _countKey = $"qb:{key}";
+        _quota = quota;
+        _period = period;
+    }
+
+    /// <summary>
+    /// Chooses the appropriate endpoint based on current quota usage.
+    /// </summary>
+    /// <param name="primary">Primary endpoint URI.</param>
+    /// <param name="secondary">Secondary endpoint URI.</param>
+    /// <param name="token">Cancellation token to observe.</param>
+    /// <returns>The selected endpoint URI.</returns>
+    /// <remarks>
+    /// This method atomically increments the quota counter in Redis. If the quota is exceeded,
+    /// the secondary endpoint is returned. When the key expires, the quota resets and the primary
+    /// endpoint will be chosen again.
+    /// </remarks>
+    public async Task<Uri> ChooseEndpointAsync(Uri primary, Uri secondary, CancellationToken token = default)
+    {
+        if (primary == null) throw new ArgumentNullException(nameof(primary));
+        if (secondary == null) throw new ArgumentNullException(nameof(secondary));
+
+        var count = await _db.StringIncrementAsync(_countKey).ConfigureAwait(false);
+        if (count == 1)
+        {
+            await _db.KeyExpireAsync(_countKey, _period).ConfigureAwait(false);
+        }
+
+        return count <= _quota ? primary : secondary;
+    }
+}

--- a/tests/DistributedCircuitBreaker.Tests.Integration/DistributedCircuitBreaker.Tests.Integration.csproj
+++ b/tests/DistributedCircuitBreaker.Tests.Integration/DistributedCircuitBreaker.Tests.Integration.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Test.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -6,11 +6,13 @@
   <ItemGroup>
     <ProjectReference Include="../../src/DistributedCircuitBreaker.Core/DistributedCircuitBreaker.Core.csproj" />
     <ProjectReference Include="../../src/DistributedCircuitBreaker.Redis/DistributedCircuitBreaker.Redis.csproj" />
+    <ProjectReference Include="../../src/DistributedQuotaCircuitBreaker.Redis/DistributedQuotaCircuitBreaker.Redis.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Testcontainers" Version="3.6.0" />
-  </ItemGroup>
-</Project>
+    <ItemGroup>
+      <PackageReference Include="xunit" Version="2.6.6" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+      <PackageReference Include="Testcontainers" Version="3.6.0" />
+      <PackageReference Include="Testcontainers.Redis" Version="3.6.0" />
+    </ItemGroup>
+  </Project>

--- a/tests/DistributedCircuitBreaker.Tests.Integration/RedisIntegrationTests.cs
+++ b/tests/DistributedCircuitBreaker.Tests.Integration/RedisIntegrationTests.cs
@@ -1,34 +1,45 @@
 using DistributedCircuitBreaker.Core;
 using DistributedCircuitBreaker.Redis;
 using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
 using Testcontainers.Redis;
+using Xunit;
+using CoreBreaker = DistributedCircuitBreaker.Core.DistributedCircuitBreaker;
 
 namespace DistributedCircuitBreaker.Tests.Integration;
 
+/// <summary>
+/// Integration tests for the Redis-backed cluster breaker store.
+/// </summary>
 public class RedisIntegrationTests : IAsyncLifetime
 {
     private readonly RedisContainer _redis = new RedisBuilder().Build();
     private IConnectionMultiplexer _mux = default!;
 
+    /// <inheritdoc />
     public async Task InitializeAsync()
     {
         await _redis.StartAsync();
         _mux = await ConnectionMultiplexer.ConnectAsync(_redis.GetConnectionString());
     }
 
+    /// <inheritdoc />
     public Task DisposeAsync()
     {
         _mux.Dispose();
         return _redis.DisposeAsync().AsTask();
     }
 
+    /// <summary>
+    /// Confirms that multiple circuit breaker instances share state via Redis.
+    /// </summary>
     [Fact]
     public async Task StateSharedBetweenInstances()
     {
         var store = new RedisClusterBreakerStore(_mux);
         var options = new CircuitBreakerOptions("redis-test", TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(10), 1, 0.5, TimeSpan.FromSeconds(1), 1, 1, new RampProfile(new[]{100}, TimeSpan.FromSeconds(1),1));
-        var breakerA = new DistributedCircuitBreaker(store, options, NullLogger<DistributedCircuitBreaker>.Instance);
-        var breakerB = new DistributedCircuitBreaker(store, options, NullLogger<DistributedCircuitBreaker>.Instance);
+        var breakerA = new CoreBreaker(store, options, NullLogger<CoreBreaker>.Instance);
+        var breakerB = new CoreBreaker(store, options, NullLogger<CoreBreaker>.Instance);
         var choice = await breakerA.ChooseAsync(new("http://p"), new("http://s"), default);
         await breakerA.ReportAsync(false, choice.UseProbe, default);
         // other instance should read open state

--- a/tests/DistributedCircuitBreaker.Tests.Integration/RedisQuotaIntegrationTests.cs
+++ b/tests/DistributedCircuitBreaker.Tests.Integration/RedisQuotaIntegrationTests.cs
@@ -1,0 +1,49 @@
+using DistributedQuotaCircuitBreaker.Redis;
+using StackExchange.Redis;
+using Testcontainers.Redis;
+using Xunit;
+
+namespace DistributedCircuitBreaker.Tests.Integration;
+
+/// <summary>
+/// Integration tests for the <see cref="RedisQuotaCircuitBreaker"/> using a real Redis container.
+/// </summary>
+public class RedisQuotaIntegrationTests : IAsyncLifetime
+{
+    private readonly RedisContainer _redis = new RedisBuilder().Build();
+    private IConnectionMultiplexer _mux = default!;
+
+    /// <inheritdoc />
+    public async Task InitializeAsync()
+    {
+        await _redis.StartAsync();
+        _mux = await ConnectionMultiplexer.ConnectAsync(_redis.GetConnectionString());
+    }
+
+    /// <inheritdoc />
+    public Task DisposeAsync()
+    {
+        _mux.Dispose();
+        return _redis.DisposeAsync().AsTask();
+    }
+
+    /// <summary>
+    /// Ensures traffic is diverted to the secondary endpoint after exceeding the quota
+    /// and returns to the primary endpoint once the quota period elapses.
+    /// </summary>
+    [Fact]
+    public async Task RoutesToSecondaryWhenQuotaExceededAndResets()
+    {
+        var breaker = new RedisQuotaCircuitBreaker(_mux, "quota-test", quota: 2, period: TimeSpan.FromMilliseconds(200));
+        var primary = new Uri("http://p");
+        var secondary = new Uri("http://s");
+
+        Assert.Equal(primary, await breaker.ChooseEndpointAsync(primary, secondary));
+        Assert.Equal(primary, await breaker.ChooseEndpointAsync(primary, secondary));
+        Assert.Equal(secondary, await breaker.ChooseEndpointAsync(primary, secondary));
+
+        await Task.Delay(250);
+
+        Assert.Equal(primary, await breaker.ChooseEndpointAsync(primary, secondary));
+    }
+}


### PR DESCRIPTION
## Summary
- add Redis-backed quota circuit breaker that switches to secondary endpoint when quota exceeded
- include integration test exercising quota reset behavior
- document circuit breaker and integration tests
