### PR TITLE
Add chaos demo sample for circuit breaker failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A production-grade distributed circuit breaker for .NET 8 with Redis-backed shar
 - `DistributedCircuitBreaker.Polly` – Polly adapter
 - `DistributedCircuitBreaker.Tests.Unit` / `Integration`
 - `DistributedCircuitBreaker.Benchmarks`
-- `samples/Sample.Web`
+- `samples/Sample.Web` – chaos testing sample with primary/secondary failover
 
 ## Getting Started
 ```bash

--- a/samples/Sample.Web/Program.cs
+++ b/samples/Sample.Web/Program.cs
@@ -5,24 +5,73 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using StackExchange.Redis;
 
-var builder = WebApplication.CreateBuilder(args);
-var conn = await ConnectionMultiplexer.ConnectAsync(builder.Configuration.GetConnectionString("redis") ?? "localhost:6379");
+var primaryApp = BuildPrimaryApi();
+var secondaryApp = BuildSecondaryApi();
+var app = await BuildDemoApiAsync(args);
 
-builder.Services.AddSingleton<IConnectionMultiplexer>(conn);
-builder.Services.AddSingleton<IClusterBreakerStore, RedisClusterBreakerStore>();
-builder.Services.AddDistributedCircuitBreaker(opts =>
+await Task.WhenAll(
+    primaryApp.RunAsync(),
+    secondaryApp.RunAsync(),
+    app.RunAsync());
+
+static WebApplication BuildPrimaryApi()
 {
-    builder.Configuration.GetSection("CircuitBreaker").Bind(opts);
-});
-builder.Services.AddDualEndpointHttpClient("OrdersClient", new Uri("https://primary"), new Uri("https://secondary"));
+    var builder = WebApplication.CreateBuilder();
+    builder.WebHost.UseUrls("http://localhost:5010");
+    var app = builder.Build();
+    app.MapGet("/", () =>
+    {
+        // 70% failure rate to trigger circuit breaker
+        if (Random.Shared.NextDouble() < 0.7)
+        {
+            return Results.Problem("Primary failure", statusCode: 500);
+        }
+        return Results.Ok("Primary response");
+    });
+    return app;
+}
 
-builder.Services.AddOpenTelemetry().WithTracing(t => t.AddAspNetCoreInstrumentation().AddOtlpExporter()).WithMetrics(m => m.AddAspNetCoreInstrumentation().AddOtlpExporter());
-
-var app = builder.Build();
-app.MapGet("/call", async (IHttpClientFactory factory) =>
+static WebApplication BuildSecondaryApi()
 {
-    var client = factory.CreateClient("OrdersClient");
-    return await client.GetStringAsync("/");
-});
+    var builder = WebApplication.CreateBuilder();
+    builder.WebHost.UseUrls("http://localhost:5020");
+    var app = builder.Build();
+    app.MapGet("/", () => Results.Ok("Secondary response"));
+    return app;
+}
 
-app.Run();
+static async Task<WebApplication> BuildDemoApiAsync(string[] args)
+{
+    var builder = WebApplication.CreateBuilder(args);
+    var conn = await ConnectionMultiplexer.ConnectAsync(builder.Configuration.GetConnectionString("redis") ?? "localhost:6379");
+
+    builder.Services.AddSingleton<IConnectionMultiplexer>(conn);
+    builder.Services.AddSingleton<IClusterBreakerStore, RedisClusterBreakerStore>();
+    builder.Services.AddDistributedCircuitBreaker(opts =>
+    {
+        builder.Configuration.GetSection("CircuitBreaker").Bind(opts);
+    });
+    builder.Services.AddDualEndpointHttpClient("ChaosClient", new("http://localhost:5010"), new("http://localhost:5020"));
+
+    builder.Services.AddOpenTelemetry()
+        .WithTracing(t => t.AddAspNetCoreInstrumentation())
+        .WithMetrics(m => m.AddAspNetCoreInstrumentation());
+
+    var app = builder.Build();
+    app.MapGet("/call", async (IHttpClientFactory factory) =>
+    {
+        var client = factory.CreateClient("ChaosClient");
+        var response = await client.GetAsync("/");
+        var body = await response.Content.ReadAsStringAsync();
+        return Results.Json(new
+        {
+            endpoint = response.RequestMessage?.RequestUri?.ToString(),
+            status = (int)response.StatusCode,
+            body
+        });
+    });
+
+    app.MapGet("/breaker", (IDistributedCircuitBreaker breaker) => breaker.State.ToString());
+
+    return app;
+}

--- a/samples/Sample.Web/README.md
+++ b/samples/Sample.Web/README.md
@@ -1,0 +1,36 @@
+# Circuit Breaker Chaos Sample
+
+This sample demonstrates the `DistributedCircuitBreaker` library with a failing primary endpoint and automatic failover to a secondary endpoint.
+
+## Architecture
+
+The project hosts three minimal APIs in the same process:
+
+- **Primary API** (`http://localhost:5010`) – randomly fails to simulate an unstable service.
+- **Secondary API** (`http://localhost:5020`) – always succeeds and acts as the fallback.
+- **Demo API** (`http://localhost:5000`) – exposes endpoints to invoke the client and inspect the breaker state.
+
+All HTTP calls from the demo API use `DualEndpointHttpClient`, which consults the circuit breaker before each request. When failures exceed the configured threshold, traffic automatically switches from the primary to the secondary API.
+
+## Prerequisites
+
+- .NET 8 SDK
+- A Redis instance available at `localhost:6379`
+
+## Running the sample
+
+```bash
+dotnet run --project samples/Sample.Web
+```
+
+In another terminal, issue repeated requests:
+
+```bash
+# Send a request that is routed through the circuit breaker
+curl http://localhost:5000/call
+
+# Inspect the current breaker state (Closed, Open, HalfOpen)
+curl http://localhost:5000/breaker
+```
+
+Observe the `endpoint` field in the `/call` response. After enough failures, it switches from `5010` (primary) to `5020` (secondary), demonstrating automatic failover. The `/breaker` endpoint reports the breaker state so you can visualize when the circuit opens and closes.

--- a/samples/Sample.Web/appsettings.json
+++ b/samples/Sample.Web/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "CircuitBreaker": {
+    "Key": "chaos-sample",
+    "Window": "00:00:30",
+    "Bucket": "00:00:05",
+    "MinSamples": 3,
+    "FailureRateToOpen": 0.5,
+    "OpenCooldown": "00:00:10",
+    "HalfOpenMaxProbes": 1,
+    "HalfOpenSuccessesToClose": 2
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- simulate primary service instability with 70% failure rate
- add demo API using DualEndpointHttpClient to failover between primary and secondary
- document running chaos sample and update project list
